### PR TITLE
Fix comments lead to broken proto files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ repository = "https://github.com/ncrothers/tonic-flatbuffers.git"
 license = "MIT"
 
 [workspace]
+resolver = "2"
 members = ["tonic-flatbuffers", "tonic-flatbuffers-build", "examples/helloworld"]

--- a/examples/helloworld/fbs/service.fbs
+++ b/examples/helloworld/fbs/service.fbs
@@ -14,7 +14,9 @@ root_type Request;
 root_type Response;
 
 rpc_service HelloWorldStreaming {
+    /// Documentation comment
     HelloSingle(Request):Response (streaming: "none");
+    // Comment
     HelloStreamServer(Request): Response (streaming: "server");
     HelloStreamClient(Request): Response (streaming: "client");
     HelloStreamBidirectional(Request): Response (streaming: "bidi");

--- a/tonic-flatbuffers-build/src/builder.rs
+++ b/tonic-flatbuffers-build/src/builder.rs
@@ -289,7 +289,22 @@ impl Builder {
 
         // Convert all flatbuffer RPC definitions into protobuf RPC definitions
         for file in fbs {
-            let file = std::fs::read_to_string(file)?.replace(['\r', '\n'], "");
+            let file = std::fs::read_to_string(file)?;
+
+            // cleanup comments above rpc definition using // or ///
+            let file = file
+                .lines()
+                .filter_map(|line| {
+                    if !line.trim_start().starts_with("//") {
+                        Some(line.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join("\n");
+
+            let file = file.replace(['\r', '\n'], "");
 
             let mut service_bufs = Vec::new();
             let mut idx = 0;


### PR DESCRIPTION
A valid fbs definition like this:
```
rpc_service MonitoringService{
  /// FOOOO BAR
  ListEvents(EventFilter): EventList;
  /// BAZ
  AwaitEvent(AwaitEventRequest): Event;
  ReceiveEvents(EventFilter): Event(streaming: "server");
}
```

Will generate a broken proto file due to the comments:
```
service MonitoringService {
    rpc /// FOOOO BAR  ListEvents (portal_data.OwnedEventFilter) returns (portal_data.OwnedEventList);
    rpc /// BAZ  AwaitEvent (portal_data.OwnedAwaitEventRequest) returns (portal_data.OwnedEvent);
    rpc ReceiveEvents (portal_data.OwnedEventFilter) returns (stream portal_data.OwnedEvent);
}
```

By stripping all comments, the protofile is generated correctly.